### PR TITLE
Fix: Scrape auth failure fix

### DIFF
--- a/.github/workflows/scrape.yaml
+++ b/.github/workflows/scrape.yaml
@@ -10,4 +10,6 @@ jobs:
         run: |
           curl --request POST \
           --url 'https://wine-scraper.vercel.app/api/scrape-new-prices' \
-          --header 'Authorization: Bearer ${{ secrets.SCRAPEKEY_SECRET }}'
+          --header "Authorization: Bearer ${SCRAPEKEY_SECRET}"
+env:
+  SCRAPEKEY_SECRET: ${{ secrets.SCRAPEKEY_SECRET }}


### PR DESCRIPTION
Should fix env vars not being available in the github workflow to scrape
